### PR TITLE
 Add AMDGPU target for aarch64 build as well

### DIFF
--- a/org.freedesktop.Sdk.Extension.llvm17.json
+++ b/org.freedesktop.Sdk.Extension.llvm17.json
@@ -90,7 +90,7 @@
             "cxxflags": "-Qunused-arguments",
             "config-opts": [
               "-DLLVM_DEFAULT_TARGET_TRIPLE=aarch64-unknown-linux-gnu",
-              "-DLLVM_TARGETS_TO_BUILD='AArch64;NVPTX;WebAssembly'"
+              "-DLLVM_TARGETS_TO_BUILD='AArch64;AMDGPU;NVPTX;WebAssembly'"
             ]
           },
           "x86_64": {


### PR DESCRIPTION
It's nice to have and better matches the way llvm is built in the runtime.

Mirror of https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm16/pull/12
